### PR TITLE
atualiza action:render_books

### DIFF
--- a/.github/workflows/render_books.yml
+++ b/.github/workflows/render_books.yml
@@ -1,4 +1,5 @@
-name: Renderizar Books com Quarto
+name: render_books
+# Descrição: Renderiza livros em Quarto e executa tarefas pós-processamento
 
 on:
   workflow_dispatch:

--- a/.github/workflows/render_books.yml
+++ b/.github/workflows/render_books.yml
@@ -5,13 +5,13 @@ on:
   schedule:
     - cron: "0 0 16 * 1"
   push:
-    branches: [main, dev1]
+    branches: [main]
     paths:
       - "**/build/*.qmd"
       - "**/build/*.yml"
       - "**/.github/workflows/*book*.yml"
   pull_request:
-    branches: [main, dev1]
+    branches: [main]
     paths:
       - "**/build/*.qmd"
       - "**/build/*.yml"
@@ -61,8 +61,8 @@ jobs:
           echo "subfolders=$MATCHED_SUBFOLDERS" >> $GITHUB_OUTPUT
 
   build:
+    needs: [detect]
     runs-on: ubuntu-latest
-    needs: detect
     if: ${{ needs.detect.outputs.subfolders != '' }}
     env:
       SUBFOLDERS: ${{ needs.detect.outputs.subfolders }}
@@ -123,3 +123,32 @@ jobs:
         run: |
           git add .
           git diff --cached --quiet || (git commit -m "Atualizações automáticas: Ambiente de teste" && git push)
+
+# Usando css e js direto de https://www.estatistica.pro
+# Logo, não será necessário gerar os mesmos neste repositório
+  clean:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checar o repositório
+        uses: actions/checkout@v4
+
+      # - name: Limpar arquivos temporários
+      #   run: |
+      #     echo "Limpando arquivos temporários..." 
+
+      - name: Excluir arquivos gerados pelo Quarto
+        run: |
+          set -e
+          if [ -d "delete" ]; then
+            echo "Excluindo diretório '/delete/'"
+            rm -rf delete
+          else
+            echo "Diretório 'delete' não encontrado."
+          fi
+          if [ -d "ac" ]; then
+            echo "Excluindo diretório 'ac'..."
+            rm -rf ac
+          else
+            echo "Diretório 'ac' não encontrado."
+          fi


### PR DESCRIPTION
This pull request updates the `.github/workflows/render_books.yml` file to improve workflow clarity, refine branch targeting, and add a new cleanup job. The most significant changes include renaming the workflow, limiting branch triggers, reorganizing job dependencies, and introducing a cleanup step to manage generated files.

### Workflow clarity and branch targeting:

* Renamed the workflow from `Renderizar Books com Quarto` to `render_books` and added a description to clarify its purpose.
* Limited branch triggers to `main` by removing `dev1` from both `push` and `pull_request` events.

### Job dependency and execution:

* Adjusted the `build` job to explicitly depend on the `detect` job using the `needs` attribute for better readability and organization.

### Cleanup process:

* Added a new `clean` job that runs after the `build` job to delete specific directories (`delete` and `ac`) if they exist, ensuring no unnecessary files remain in the repository.