### PR TITLE
fix: remove branch configuration and PR creation steps in render_book…

### DIFF
--- a/.github/workflows/render_books.yml
+++ b/.github/workflows/render_books.yml
@@ -74,10 +74,6 @@ jobs:
     if: ${{ needs.detect.outputs.subfolders != '' }}
     env:
       SUBFOLDERS: ${{ needs.detect.outputs.subfolders }}
-    refs:
-      # Define a branch para o push
-      # Se não for definido, será usado o padrão do repositório
-      branch: renb
 
     steps:
       - name: Checar o repositório
@@ -153,8 +149,6 @@ jobs:
       - name: Configurar branche para push
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git checkout renb
-          git fetch origin main
 
       - name: Configurar Usuario Git
         run: |
@@ -162,20 +156,22 @@ jobs:
           git config --global user.email "${{ secrets.USEREMAIL }}"
 
       - name: Commitar e enviar mudanças se houver alterações
+        with:
+          branch: 'renb'
         run: |
-          # git checkout renb
+          git checkout renb
           git add .
           git diff --cached --quiet || (git commit -m "Atualizações automáticas: Renderização de livros" && git push)
           git push origin renb
 
-      - name: Criar Pull Request  
-        uses: peter-evans/create-pull-request@v4
-        with:
-          branch: renb
-          title: "Atualizações automáticas: Renderização de livros"
-          body: "Este PR foi gerado automaticamente pelo workflow de renderização de livros."
-          base: main
-          labels: "automático, renderização, livro"
-          delete-branch: true
-          draft: false
-          reviewers: ${{ secrets.REVIEWERS }}
+      # - name: Criar Pull Request  
+      #   uses: peter-evans/create-pull-request@v4
+      #   with:
+      #     branch: renb
+      #     title: "Atualizações automáticas: Renderização de livros"
+      #     body: "Este PR foi gerado automaticamente pelo workflow de renderização de livros."
+      #     base: main
+      #     labels: "automático, renderização, livro"
+      #     delete-branch: true
+      #     draft: false
+      #     reviewers: ${{ secrets.REVIEWERS }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/render_books.yml` file to streamline the workflow for rendering books. The changes focus on simplifying branch handling and modifying the pull request creation step.

### Workflow simplifications:

* Removed the `refs` section specifying the branch for the push operation, as it is now explicitly handled in the `with` block of the commit-and-push step. (`[.github/workflows/render_books.ymlL77-L80](diffhunk://#diff-a84f6d487969f9dab056e29beb551e24033e0bf7a72592ed66239ebc1774666fL77-L80)`)
* Simplified the pull request creation step by commenting out the block that uses the `peter-evans/create-pull-request` action. This step is now effectively disabled. (`[.github/workflows/render_books.ymlL156-R177](diffhunk://#diff-a84f6d487969f9dab056e29beb551e24033e0bf7a72592ed66239ebc1774666fL156-R177)`)…s workflow